### PR TITLE
test for tridiagonal linear operator

### DIFF
--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -15,7 +15,6 @@
 import pytest
 
 import jax.numpy as jnp
-import jax.random as rdm
 import lineax as lx
 
 import traceax as tx


### PR DESCRIPTION
1. constructed a matrix with `lx.tridiagonal_tag` ([ref](https://docs.kidger.site/lineax/api/tags))
2. generated diagonals of that matrix with `jnp.diag` ([ref](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.diag.html))
3. tested 3 simple cases like previous ones