### PR TITLE
tests for compound and tagged linear operators

### DIFF
--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -112,7 +112,7 @@ def test_tridiagonal_linop(getkey, estimator, k, size, dtype):
     upper_diag = jnp.diag(matrix, k=1)
     operator = lx.TridiagonalLinearOperator(main_diag, lower_diag, upper_diag)
     result = tx.trace(getkey(), operator, k, estimator)
-    
+
     assert result is not None
     assert result.value is not None
     assert jnp.isfinite(result.value)
@@ -130,7 +130,7 @@ def test_identity_linop(getkey, estimator, k, size, dtype):
     input_structure = jax.ShapeDtypeStruct((size,), dtype)
     operator = lx.IdentityLinearOperator(input_structure)
     result = tx.trace(getkey(), operator, k, estimator)
-    
+
     assert result is not None
     assert result.value is not None
     assert jnp.isfinite(result.value)
@@ -156,7 +156,7 @@ def test_identity_linop(getkey, estimator, k, size, dtype):
 )
 @pytest.mark.parametrize("size", (5, 50, 500))
 @pytest.mark.parametrize("dtype", (jnp.float32, jnp.float64))
-def test_tagged_linear_operator(getkey, estimator, k, tags, size, dtype):
+def test_tagged_linop(getkey, estimator, k, tags, size, dtype):
     k = min(k, size)
     matrix = construct_matrix(getkey, tags, size, dtype)
     operator = lx.MatrixLinearOperator(matrix, tags=tags)
@@ -166,3 +166,72 @@ def test_tagged_linear_operator(getkey, estimator, k, tags, size, dtype):
     assert result is not None
     assert result.value is not None
     assert jnp.isfinite(result.value)
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    (tx.HutchinsonEstimator(), tx.HutchPlusPlusEstimator(), tx.XTraceEstimator()),
+)
+@pytest.mark.parametrize(
+    "tags",
+    (
+        None,
+        lx.diagonal_tag,
+        lx.symmetric_tag,
+        lx.lower_triangular_tag,
+        lx.upper_triangular_tag,
+        lx.tridiagonal_tag,
+        lx.unit_diagonal_tag,
+        lx.positive_semidefinite_tag,
+        lx.negative_semidefinite_tag,
+    ),
+)
+@pytest.mark.parametrize("k", (5, 10, 50))
+@pytest.mark.parametrize("size", (5, 50, 500))
+@pytest.mark.parametrize("dtype", (jnp.float32, jnp.float64))
+def test_compound_op(getkey, estimator, k, tags, size, dtype):
+    k = min(k, size)
+    matrix_a = construct_matrix(getkey, tags, size, dtype)
+    matrix_b = construct_matrix(getkey, tags, size, dtype)
+    op_a = lx.MatrixLinearOperator(matrix_a, tags=tags)
+    op_b = lx.MatrixLinearOperator(matrix_b, tags=tags)
+
+    """AddLinearOperator"""
+    add_op = op_a + op_b
+    add_result = tx.trace(getkey(), add_op, k, estimator)
+
+    assert add_result is not None
+    assert add_result.value is not None
+    assert jnp.isfinite(add_result.value)
+
+    """ComposedLinearOperator"""
+    composed_op = op_a @ op_b
+    composed_result = tx.trace(getkey(), composed_op, k, estimator)
+
+    assert composed_result is not None
+    assert composed_result.value is not None
+    assert jnp.isfinite(composed_result.value)
+
+    """MulLinearOperator"""
+    scalar = 0.5 # random value
+    mul_op = scalar * op_a
+    mul_result = tx.trace(getkey(), mul_op, k, estimator)
+
+    assert mul_result is not None
+    assert mul_result.value is not None
+    assert jnp.isfinite(mul_result.value)
+
+    """NegLinearOperator"""
+    neg_result = tx.trace(getkey(), -op_a, k, estimator)
+
+    assert neg_result is not None
+    assert neg_result.value is not None
+    assert jnp.isfinite(neg_result.value)
+
+    """DivLinearOperator"""
+    denom = 0.5 # random value
+    div_result = tx.trace(getkey(), op_b/denom, k, estimator)
+
+    assert div_result is not None
+    assert div_result.value is not None
+    assert jnp.isfinite(div_result.value)

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -167,6 +167,15 @@ def test_tagged_linop(getkey, estimator, k, tags, size, dtype):
     assert result.value is not None
     assert jnp.isfinite(result.value)
 
+    sym_operator = operator + operator.T
+    sym_operator = lx.TaggedLinearOperator(sym_operator, lx.symmetric_tag)
+    sym_result = tx.trace(getkey(), sym_operator, k, estimator)
+
+    assert lx.is_symmetric(sym_operator)
+    assert sym_result is not None
+    assert sym_result.value is not None
+    assert jnp.isfinite(sym_result.value)
+
 
 @pytest.mark.parametrize(
     "estimator",


### PR DESCRIPTION
added tests for compound operators:
1. `AddLinearOperator`
2. `ComposedLinearOperator`
3. `MulLinearOperator`
4. `NegLinearOperator`
5. `DivLinearOperator`

added test for tagged linear operator with symmetric tag